### PR TITLE
Feat log host

### DIFF
--- a/monitoring/agent-compose.yml
+++ b/monitoring/agent-compose.yml
@@ -13,8 +13,6 @@ services:
       - ./promtail-config.yml:/etc/promtail/promtail-config.yml
     networks:
       - monitor
-    command: 
-      - "-config.expand-env=true"
 
   cadvisor:
     container_name: cadvisor

--- a/monitoring/agent-compose.yml
+++ b/monitoring/agent-compose.yml
@@ -6,11 +6,15 @@ services:
   promtail:
     container_name: promtail
     image: grafana/promtail:latest
+    environment:
+      - /home/ec2-user/orchestration/.env
     volumes:
       - /var/log/:/var/log/
       - ./promtail-config.yml:/etc/promtail/promtail-config.yml
     networks:
       - monitor
+    command: 
+      - "-config.expand-env=true"
 
   cadvisor:
     container_name: cadvisor

--- a/monitoring/agent-compose.yml
+++ b/monitoring/agent-compose.yml
@@ -13,9 +13,6 @@ services:
       - ./promtail-config.yml:/etc/promtail/promtail-config.yml
     networks:
       - monitor
-    command:
-      -client.external_labels=agent=${LOG_HOST}
-      -config.expand-env=true
 
   cadvisor:
     container_name: cadvisor

--- a/monitoring/agent-compose.yml
+++ b/monitoring/agent-compose.yml
@@ -6,7 +6,7 @@ services:
   promtail:
     container_name: promtail
     image: grafana/promtail:latest
-    environment:
+    env_file:
       - /home/ec2-user/orchestration/.env
     volumes:
       - /var/log/:/var/log/

--- a/monitoring/agent-compose.yml
+++ b/monitoring/agent-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./promtail-config.yml:/etc/promtail/promtail-config.yml
     networks:
       - monitor
+    command: "-config.expand-env=true -config.file=/etc/promtail/promtail-config.yml"
 
   cadvisor:
     container_name: cadvisor

--- a/monitoring/agent-compose.yml
+++ b/monitoring/agent-compose.yml
@@ -13,6 +13,9 @@ services:
       - ./promtail-config.yml:/etc/promtail/promtail-config.yml
     networks:
       - monitor
+    command:
+      -client.external_labels=agent=${LOG_HOST}
+      -config.expand-env=true
 
   cadvisor:
     container_name: cadvisor

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -8,7 +8,7 @@ positions:
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
     external_labels:
-      agent: "{{ LOG_HOST }}"
+      agent: ${LOG_HOST}
 
 scrape_configs:
 - job_name: system

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -16,6 +16,7 @@ scrape_configs:
     labels:
       job: varlogs
       __path__: /var/log/*log
+      log_host: ${LOG_HOST}
 
 - job_name: docker
   static_configs:
@@ -24,6 +25,7 @@ scrape_configs:
     labels:
       job: docker_logs
       __path__: /var/lib/docker/containers/*/*-json.log
+      log_host: ${LOG_HOST}
 
 - job_name: docker_log_scrape
   docker_sd_configs:

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -7,6 +7,8 @@ positions:
 
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
+    external_labels:
+      agent: {{ LOG_HOST }}
 
 scrape_configs:
 - job_name: system
@@ -16,9 +18,6 @@ scrape_configs:
   - labels:
       job: varlogs
       __path__: /var/log/*log
-  pipeline_stages:
-    - static_labels:
-        agent: 'test'
 
 - job_name: docker
   static_configs:
@@ -27,9 +26,6 @@ scrape_configs:
   - labels:
       job: docker_logs
       __path__: /var/lib/docker/containers/*/*-json.log
-  pipeline_stages:
-    - static_labels:
-        agent: 'test'
 
 - job_name: docker_log_scrape
   docker_sd_configs:
@@ -46,6 +42,3 @@ scrape_configs:
       target_label: 'logstream'
     - source_labels: ['__meta_docker_container_label_logging_jobname']
       target_label: 'job'  
-  pipeline_stages:
-    - static_labels:
-        agent: 'test'

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -8,7 +8,7 @@ positions:
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
     external_labels:
-      agent: "test"
+      agent: "{{ LOG_HOST }}"
 
 scrape_configs:
 - job_name: system

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -13,23 +13,23 @@ scrape_configs:
   static_configs:
   - targets:
       - localhost
-    labels:
+  - labels:
       job: varlogs
       __path__: /var/log/*log
   pipeline_stages:
-  - labels:
-      log_host: ${LOG_HOST}
+    - static_labels:
+        agent: 'test'
 
 - job_name: docker
   static_configs:
   - targets:
       - localhost
-    labels:
+  - labels:
       job: docker_logs
       __path__: /var/lib/docker/containers/*/*-json.log
   pipeline_stages:
-  - labels:
-      log_host: ${LOG_HOST}
+    - static_labels:
+        agent: 'test'
 
 - job_name: docker_log_scrape
   docker_sd_configs:
@@ -46,3 +46,6 @@ scrape_configs:
       target_label: 'logstream'
     - source_labels: ['__meta_docker_container_label_logging_jobname']
       target_label: 'job'  
+  pipeline_stages:
+    - static_labels:
+        agent: 'test'

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -8,7 +8,7 @@ positions:
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
     external_labels:
-      agent: test
+      agent: ${LOG_HOST}
 
 scrape_configs:
 - job_name: system

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -8,7 +8,7 @@ positions:
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
     external_labels:
-      agent: 'test'
+      agent: "test"
 
 scrape_configs:
 - job_name: system

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -16,6 +16,8 @@ scrape_configs:
     labels:
       job: varlogs
       __path__: /var/log/*log
+  pipeline_stages:
+  - labels:
       log_host: ${LOG_HOST}
 
 - job_name: docker
@@ -25,6 +27,8 @@ scrape_configs:
     labels:
       job: docker_logs
       __path__: /var/lib/docker/containers/*/*-json.log
+  pipeline_stages:
+  - labels:
       log_host: ${LOG_HOST}
 
 - job_name: docker_log_scrape

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -8,7 +8,7 @@ positions:
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
     external_labels:
-      agent: {{ LOG_HOST }}
+      agent: 'test'
 
 scrape_configs:
 - job_name: system

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -8,7 +8,7 @@ positions:
 clients:
   - url: http://54.188.253.144:3100/loki/api/v1/push
     external_labels:
-      agent: ${LOG_HOST}
+      agent: test
 
 scrape_configs:
 - job_name: system


### PR DESCRIPTION
Got it.
Logging will pull the LOG_HOST value from the .env file, and add it to every log transmitted to loki as an 'agent' label. Two little changes, just a lot of troubleshooting to figure out that I was using 'expanded' instead of 'expand'. dumb me.