### PR TITLE
loki logs to volume, add rotation

### DIFF
--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -4,35 +4,33 @@ server:
   http_listen_port: 3100
   grpc_listen_port: 9096
 
-common:
-  instance_addr: 
-    - 35.94.250.154
-    - 44.239.41.57
-    - 44.226.153.74
-    - 52.26.101.232
-  path_prefix: /tmp/loki
-  storage:
-    filesystem:
-      chunks_directory: /tmp/loki/chunks
-      rules_directory: /tmp/loki/rules
-  replication_factor: 1
-  ring:
-    kvstore:
-      store: inmemory
-
-query_range:
-  results_cache:
-    cache:
-      embedded_cache:
-        enabled: true
-        max_size_mb: 100
-
 schema_config:
   configs:
-    - from: 2020-10-24
-      store: tsdb
-      object_store: filesystem
-      schema: v12
+    - from: "2024-01-01"
       index:
-        prefix: index_
         period: 24h
+        prefix: index_
+      object_store: filesystem
+      schema: v13
+      store: tsdb
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: index
+    cache_location: cache
+    shared_store: filesystem
+  filesystem:
+    directory: chunks
+
+compactor:
+  retention_enabled: true
+
+limits-config:
+  retention_period: 336h # 14 days
+
+
+query_scheduler:
+  max_outstanding_requests_per_tenant: 32768
+
+querier:
+  max_concurrent: 16

--- a/monitoring/monitor-compose.yml
+++ b/monitoring/monitor-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "3100:3100"
     volumes:
+      - /home/ubuntu/loki-data:/loki
       - ./loki-config.yml:/etc/loki/loki-config.yml
     networks:
       - monitor
@@ -20,6 +21,8 @@ services:
     pull_policy: always
     ports:
       - "9091:9091"
+    volumes:
+      - ./pushgateway-data:/data
     networks:
       - monitor
     

--- a/orchestration/docker-compose.yml
+++ b/orchestration/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-        loki-url: "http://54.188.253.144:3100/loki/api/v1/push"
+        loki-url: "http://34.223.156.189:3100/loki/api/v1/push"
         loki-external-labels: "job=web,container=web,agent=${LOG_HOST}"
 
   celery-worker:
@@ -50,7 +50,7 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-        loki-url: "http://54.188.253.144:3100/loki/api/v1/push"
+        loki-url: "http://34.223.156.189:3100/loki/api/v1/push"
         loki-external-labels: "job=celery-worker,container=celery-worker,agent=${LOG_HOST}"
 
   celery-beat:
@@ -73,7 +73,7 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-        loki-url: "http://54.188.253.144:3100/loki/api/v1/push"
+        loki-url: "http://34.223.156.189:3100/loki/api/v1/push"
         loki-external-labels: "job=celery-beat,container=celery-beat,agent=${LOG_HOST}"
       
   frontend:
@@ -91,7 +91,7 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-        loki-url: "http://54.188.253.144:3100/loki/api/v1/push"
+        loki-url: "http://34.223.156.189:3100/loki/api/v1/push"
         loki-external-labels: "job=frontend,container=frontend,agent=${LOG_HOST}"
 
   redis:
@@ -107,7 +107,7 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-        loki-url: "http://54.188.253.144:3100/loki/api/v1/push"
+        loki-url: "http://34.223.156.189:3100/loki/api/v1/push"
         loki-external-labels: "job=redis,container=redis,agent=${LOG_HOST}"
 
   nginx:
@@ -132,5 +132,5 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-        loki-url: "http://54.188.253.144:3100/loki/api/v1/push"
+        loki-url: "http://34.223.156.189:3100/loki/api/v1/push"
         loki-external-labels: "job=nginx,container=nginx,agent=${LOG_HOST}"


### PR DESCRIPTION
some monitoring tweaks that should help keep the monitor alive.

shifted lokis logs to a volume to persist after container restart
added log rotation every 2 weeks to not overwhelm the memory