### PR TITLE
runners to update IP on start/stop with metrics across the board

### DIFF
--- a/backend/app/business/runner_management.py
+++ b/backend/app/business/runner_management.py
@@ -940,7 +940,7 @@ async def start_runner(runner_id: int, initiated_by: str = "user") -> dict:
 
             new_runner_url = await cloud_service.get_instance_ip(instance_id)
             logger.info(f"[{initiated_by}] Updated runner url for runner {runner_id}: {new_runner_url}")
-                        
+
             runner.url = new_runner_url
             session.add(runner)
             session.commit()

--- a/backend/app/business/runner_management.py
+++ b/backend/app/business/runner_management.py
@@ -944,7 +944,7 @@ async def start_runner(runner_id: int, initiated_by: str = "user") -> dict:
             runner.url = new_runner_url
             session.add(runner)
             session.commit()
-            
+
             # Run node_exporter.sh script
             node_exporter_result = await script_management.run_custom_script_for_runner(
                 runner_id=runner_id,

--- a/backend/app/tasks/shutdown_runner.py
+++ b/backend/app/tasks/shutdown_runner.py
@@ -248,8 +248,8 @@ def stop_instance(resources, initiated_by, result):
                 "status": "success",
                 "message": "Instance stopped"
             })
-            
-            # Call terminate_runner_logs after instance is terminated
+
+        # Call terminate_runner_logs after instance is terminated
         try:
             from app.business.runner_management import terminate_runner_logs
             asyncio.run(terminate_runner_logs(resources['id'], initiated_by))

--- a/backend/app/tasks/shutdown_runner.py
+++ b/backend/app/tasks/shutdown_runner.py
@@ -248,6 +248,15 @@ def stop_instance(resources, initiated_by, result):
                 "status": "success",
                 "message": "Instance stopped"
             })
+            
+            # Call terminate_runner_logs after instance is terminated
+        try:
+            from app.business.runner_management import terminate_runner_logs
+            asyncio.run(terminate_runner_logs(resources['id'], initiated_by))
+            logger.info(f"[{initiated_by}] Called terminate_runner_logs for runner {runner_id}")
+        except Exception as log_cleanup_exc:
+            logger.error(f"[{initiated_by}] Error calling terminate_runner_logs for runner {runner_id}: {log_cleanup_exc}")
+
             return True
         else:
             message = f"Failed to update runner {resources['runner'].id} state to 'closed'"


### PR DESCRIPTION
Last update to the runner-pool-claim to help with metric IP updating appropriately on start/stop.